### PR TITLE
Potential fix for code scanning alert no. 2: Redundant null check due to previous dereference

### DIFF
--- a/gr-blocks/lib/file_meta_source_impl.cc
+++ b/gr-blocks/lib/file_meta_source_impl.cc
@@ -271,12 +271,13 @@ bool file_meta_source_impl::_open(FILE** fp, const char* filename)
         fp = 0;
     }
 
-    if ((*fp = fdopen(fd, "rb")) == NULL) {
+    if (fp == NULL || (*fp = fdopen(fd, "rb")) == NULL) {
         d_logger->error("[fdopen] {:s}: {:s}", filename, strerror(errno));
         ::close(fd); // don't leak file descriptor if fdopen fails.
+        return false; // return early if fp is null
     }
 
-    ret = fp != 0;
+    ret = true;
 
     return ret;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/octodevark/gnuradio/security/code-scanning/2](https://github.com/octodevark/gnuradio/security/code-scanning/2)

To fix the issue, the null check for `fp` should be moved before the dereference at line 274. This ensures that the pointer is validated before any operations are performed on it. Specifically:
1. Check if `fp` is non-null before dereferencing it.
2. If `fp` is null, close the file descriptor (`fd`) and return `false` to prevent further operations on an invalid pointer.

This change will ensure that the code does not attempt to dereference a null pointer, eliminating the risk of undefined behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
